### PR TITLE
NoTokenGatewayを実装しました close #17

### DIFF
--- a/src/main/kotlin/com/example/apiSample/firebase/AuthGateway.kt
+++ b/src/main/kotlin/com/example/apiSample/firebase/AuthGateway.kt
@@ -1,0 +1,5 @@
+package com.example.apiSample.firebase
+
+interface AuthGateway{
+    fun verifyIdToken(id_token: String?): String?
+}

--- a/src/main/kotlin/com/example/apiSample/firebase/FirebaseGateway.kt
+++ b/src/main/kotlin/com/example/apiSample/firebase/FirebaseGateway.kt
@@ -7,9 +7,7 @@ import com.google.auth.oauth2.GoogleCredentials
 import org.springframework.stereotype.Component
 import org.slf4j.LoggerFactory
 
-interface AuthGateway{
-    fun verifyIdToken(id_token: String): String?
-}
+
 
 @Component
 class  FirebaseGateway : AuthGateway{
@@ -37,7 +35,7 @@ class  FirebaseGateway : AuthGateway{
     戻り値
     - uid: String?: 正しいJWTの場合uidを返す。正しくない場合はnull。
     */
-    override fun verifyIdToken(id_token: String): String?{
+    override fun verifyIdToken(id_token: String?): String?{
 
         try {
             val decodedToken = FirebaseAuth.getInstance().verifyIdTokenAsync(id_token).get()

--- a/src/main/kotlin/com/example/apiSample/firebase/NoTokenGateway.kt
+++ b/src/main/kotlin/com/example/apiSample/firebase/NoTokenGateway.kt
@@ -1,0 +1,19 @@
+package com.example.apiSample.firebase
+
+import org.springframework.stereotype.Component
+
+
+
+//@Component
+class  NoTokenGateway : AuthGateway{
+
+
+    /*引数
+    - id_token: String : クライアントから送られてきたJWT
+    戻り値
+    - uid: String?: 必ず"fakeid1"を返す
+    */
+    override fun verifyIdToken(id_token: String?): String?{
+        return "fakeid1"
+    }
+}

--- a/src/test/kotlin/com/example/apiSample/FirebaseGatewayTests.kt
+++ b/src/test/kotlin/com/example/apiSample/FirebaseGatewayTests.kt
@@ -20,6 +20,7 @@ class FirebaseGatewayTests{
         //初期化
         val auth = FirebaseGateway()
 
+        //2回インスタンスを作成しても大丈夫
         val auth2 = FirebaseGateway()
 
         //CASE1 : jwtの形式でない場合はnullが返ってくる。例外のログが出力される。

--- a/src/test/kotlin/com/example/apiSample/NoTokenGatewayTests.kt
+++ b/src/test/kotlin/com/example/apiSample/NoTokenGatewayTests.kt
@@ -1,0 +1,25 @@
+package com.example.apiSample
+
+import org.junit.Test
+import org.junit.Assert.*
+
+import com.example.apiSample.firebase.NoTokenGateway
+
+class NoTokenGatewayTests{
+
+    @Test
+    fun verifyIdTokenTest(){
+
+        //初期化
+        val auth = NoTokenGateway()
+
+        //CASE1 : nullでも、fakeid1が返ってくる
+        var token: String?  = null
+        assertEquals("fakeid1",auth.verifyIdToken((token)))
+
+      //CASE2 : 有効期限切れのトークンの場合でもfakeid1が返ってくる
+        token = "eyJhbGciOiJSUzI1NiIsImtpZCI6ImZmNTRmZjM0MTFiZmMwMDJiYTBjZDAwNzA2YmEzYmM4NTBiZWIwMmIifQ.U66QQ6jhWj0oh3azCVseFYsNJjwmtPB02e7W83elz91A2flwoO8nHCcoJ8oykpPIQFotKO3LZmrrP9-r0WGxxfQ-a34d7Be6HA1QfGy0_Hc0K8e_i_aObzP3gkVs8-08qbjFL2VfEmbkTh5wncMUpEAwGWCR4cWD99T3i9DzjksssYiNUXC7qHynbe_XRystZJmTWpd34HtatjXlUdS76CrSOGmxp-y9mGAlZg5DdvWQB5eefX25vd62-wZGwNUdK1YMK5FhQKaDvViUTejCqAaezhhIIcc62-TIA3YT5xcWTWM9ITKArPRP6z_pUun1_3wF532Fjq2qtyeFscO-UQ"
+        assertEquals("fakeid1",auth.verifyIdToken((token)))
+
+    }
+}


### PR DESCRIPTION
## 対象issue
#17 

## 実装一覧
- `AuthGateway`インターフェースを別ファイルに移した
- `verifyIdToken()`の引数を`nullable`にした
- 必ず`fakeid1`を返す`NoTokenGateway`を実装した
- `NoTokenGatewayTests`を実装した
- これにより`@component`を変更するだけで認証をパスしてくれるので、APIのテストをしやすくなる