### PR TITLE
Swaggerを用いたAPIドキュメントを実装しました

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,8 @@ dependencies {
 	runtime('mysql:mysql-connector-java')
 	compile ('ch.qos.logback:logback-classic:1.2.3')
 	testCompile('org.springframework.boot:spring-boot-starter-test')
+	compile 'io.springfox:springfox-swagger2:2.6.1'
+	compile 'io.springfox:springfox-swagger-ui:2.6.1'
 }
 
 jar {

--- a/src/main/kotlin/com/example/apiSample/swagger/Swagger2Config.kt
+++ b/src/main/kotlin/com/example/apiSample/swagger/Swagger2Config.kt
@@ -1,0 +1,45 @@
+package com.example.apiSample.swagger
+
+import com.google.common.base.Predicate
+import com.google.common.base.Predicates
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import springfox.documentation.service.ApiInfo
+import springfox.documentation.spi.DocumentationType
+import springfox.documentation.spring.web.plugins.Docket
+import springfox.documentation.swagger2.annotations.EnableSwagger2
+
+@Configuration
+@EnableSwagger2 // swagger(v2)を有効にする
+class Swagger2Config {
+
+    @Bean
+    fun swaggerSpringMvcPlugin(): Docket {
+        return Docket(DocumentationType.SWAGGER_2)
+                .select()
+                .paths(paths())
+                .build()
+                .apiInfo(apiInfo())
+    }
+
+    private fun paths(): Predicate<String> {
+
+        // 仕様書生成対象のURLパスを指定する
+        return Predicates.and(
+                Predicates.or(
+                        Predicates.containsPattern("/users/*"),
+                        Predicates.containsPattern("/messages/*"),
+                        Predicates.containsPattern("/rooms/*")))
+    }
+
+    private fun apiInfo(): ApiInfo {
+        return ApiInfo(
+                "Kyoto A Web API", // title
+                "Kyoto AのWebAPIの仕様書です", // description
+                "0.0.1", // version
+                "", // terms of service url
+                "Line summer intern kyoto A", // created by
+                "Line summer intern kyoto A", // license
+                "")
+    }
+}


### PR DESCRIPTION
## 概要
- Swagger UIを用いて自動的にAPIドキュメントを生成するようにしました。
- `http://localhost:8080/swagger-ui.html`でアクセスできます。
- ページから実際にPOSTやPUTも気軽に試せます。